### PR TITLE
chore(ci): use Chainguard action mirrors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
     name: 'lint'
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'chainguard-actions/actions-checkout@84880c833d491e2b948e484ac6a8ce9da42795dc' # v6
       - id: variables
         run: |
           MAKEFILE=$(find . -name Makefile -print -quit)
@@ -58,11 +58,11 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: chainguard-actions/actions-checkout@84880c833d491e2b948e484ac6a8ce9da42795dc # v6
         with:
           fetch-depth: 0
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: chainguard-actions/actions-setup-node@497ae0c79984dcc62c3b665373e96a57fffb8a84 # v6.4.0
         with:
           node-version: lts/*
       - name: Install commitlint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup node
-        uses: chainguard-actions/actions-setup-node@5220cca6dfc39e236be6378db71ac72a660ed75b # v6.3.0
+        uses: chainguard-actions/actions-setup-node@b8eacff6f5f2bed938e75d245e141bc3585415da # v6.4.0
         with:
           node-version: lts/*
       - name: Install commitlint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -62,7 +62,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup node
-        uses: chainguard-actions/actions-setup-node@497ae0c79984dcc62c3b665373e96a57fffb8a84 # v6.4.0
+        uses: chainguard-actions/actions-setup-node@5220cca6dfc39e236be6378db71ac72a660ed75b # v6.3.0
         with:
           node-version: lts/*
       - name: Install commitlint

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.repository_owner == 'GoogleCloudPlatform' || github.repository_owner == 'terraform-google-modules'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v10
+    - uses: chainguard-actions/actions-stale@e45ca0184544ad63568317fe3759d62964b31174 # v10.3.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days'


### PR DESCRIPTION
## Summary

Migrates GitHub Actions references in this repo to SHA-pinned `chainguard-actions/*` mirrors.

- Migratable hits: 4
- Distinct upstream actions: 3
- Exact tag migrations: 2
- Closest-tag fallback migrations: 2

## Actions

- `actions/checkout`
- `actions/setup-node`
- `actions/stale`

## Notes

This PR is part of the org-wide Chainguard Actions migration. The final Terraform allowlist cleanup PR is a draft and should merge only after all downstream migration PRs listed there have merged.
